### PR TITLE
Debian update

### DIFF
--- a/Dockerfile-jdk-server
+++ b/Dockerfile-jdk-server
@@ -3,8 +3,8 @@ COPY . .
 ENV LINUX_JMODS /usr/local/openjdk-14/jmods/
 RUN mvn package -DskipTests -pl swiss-wowbagger-jdk-server -am
 
-FROM bitnami/minideb
-RUN echo 'deb http://ftp.de.debian.org/debian jessie main non-free' >> /etc/apt/sources.list
+FROM bitnami/minideb:bullseye
+RUN echo 'deb http://deb.debian.org/debian bullseye contrib' >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install mbrola
 COPY --from=java swiss-wowbagger-jdk-server/target/jlink /run
 EXPOSE 7125

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </modules>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <dependency-check.fail-on-error>false</dependency-check.fail-on-error>
     </properties>
 

--- a/swiss-wowbagger-jdk-server/Dockerfile
+++ b/swiss-wowbagger-jdk-server/Dockerfile
@@ -1,5 +1,5 @@
-FROM bitnami/minideb
-RUN echo 'deb http://ftp.de.debian.org/debian jessie main non-free' >> /etc/apt/sources.list
+FROM bitnami/minideb:bullseye
+RUN echo 'deb http://deb.debian.org/debian bullseye contrib' >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y install mbrola
 ADD target/jlink /run
 EXPOSE 7125

--- a/swiss-wowbagger-jdk-server/src/main/java9/module-info.java
+++ b/swiss-wowbagger-jdk-server/src/main/java9/module-info.java
@@ -5,4 +5,5 @@ module swiss.wowbagger.server {
     requires kotlin.stdlib.jdk8;
 
     requires swiss.wowbagger;
+    requires mbrola.jvm.common;
 }

--- a/swiss-wowbagger-telegram/Dockerfile
+++ b/swiss-wowbagger-telegram/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:13
-RUN yum -y install glibc.i686
+FROM adoptopenjdk/openjdk11-openj9:debianslim-jre
+RUN echo 'deb http://deb.debian.org/debian buster contrib' >> /etc/apt/sources.list
+RUN apt-get update && apt-get -y install mbrola
 COPY target/swiss-wowbagger-telegram-0.0.2-SNAPSHOT-fat.jar /tmp/bot.jar
 CMD java -jar /tmp/bot.jar

--- a/swiss-wowbagger-telegram/pom.xml
+++ b/swiss-wowbagger-telegram/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>swiss-wowbagger-telegram</artifactId>
     <name>${project.artifactId}</name>
 
+    <properties>
+        <module.name>wowbagger.telegram</module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>guru.nidi</groupId>

--- a/swiss-wowbagger-twitter/Dockerfile
+++ b/swiss-wowbagger-twitter/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:13
-RUN yum -y install glibc.i686
+FROM adoptopenjdk/openjdk11-openj9:debianslim-jre
+RUN echo 'deb http://deb.debian.org/debian buster contrib' >> /etc/apt/sources.list
+RUN apt-get update && apt-get -y install mbrola
 COPY target/swiss-wowbagger-twitter-0.0.2-SNAPSHOT-fat.jar /tmp/bot.jar
 CMD java -jar /tmp/bot.jar

--- a/swiss-wowbagger/pom.xml
+++ b/swiss-wowbagger/pom.xml
@@ -22,8 +22,8 @@
         </dependency>
         <dependency>
             <groupId>guru.nidi</groupId>
-            <artifactId>mbrola-jvm</artifactId>
-            <version>0.0.6</version>
+            <artifactId>mbrola-jvm-common</artifactId>
+            <version>0.0.7</version>
         </dependency>
     </dependencies>
 

--- a/swiss-wowbagger/src/main/java9/module-info.java
+++ b/swiss-wowbagger/src/main/java9/module-info.java
@@ -2,7 +2,7 @@ module swiss.wowbagger {
     requires kotlin.stdlib;
     requires kotlin.stdlib.jdk7;
     requires kotlin.stdlib.jdk8;
-    requires transitive mbrola.jvm.linux;
+    requires mbrola.jvm.common;
 
     exports guru.nidi.wowbagger;
     opens guru.nidi.wowbagger;


### PR DESCRIPTION
Update swiss-wowbagger-jdk-server Debian version (wasn't supported anymore). Use mbrola command installed in OS (embedded one from mbrola-jvm doesn't run anymore on recent Debian version).

Requires changes in mbrola-jvm to be released: https://github.com/nidi3/mbrola-jvm/pull/1